### PR TITLE
Allow port re use

### DIFF
--- a/IL2-SR-Client/App.config
+++ b/IL2-SR-Client/App.config
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/IL2-SR-Client/IL2-SR-Client.csproj
+++ b/IL2-SR-Client/IL2-SR-Client.csproj
@@ -113,8 +113,8 @@
       <HintPath>..\packages\MvvmEventBinding.1.0.0\lib\net45\MvvmEventBinding.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>

--- a/IL2-SR-Client/Network/IL2/IL2RadioSyncHandler.cs
+++ b/IL2-SR-Client/Network/IL2/IL2RadioSyncHandler.cs
@@ -53,9 +53,12 @@ namespace Ciribob.IL2.SimpleRadio.Standalone.Client.Network.IL2
                 while (!_stop)
                 {
                     var localEp = new IPEndPoint(IPAddress.Any, _globalSettings.GetNetworkSetting(GlobalSettingsKeys.IL2IncomingUDP));
+                    _il2UdpListener = new UdpClient();
+                    _il2UdpListener.ExclusiveAddressUse = false;
+                    _il2UdpListener.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                     try
                     {
-                        _il2UdpListener = new UdpClient(localEp);
+                        _il2UdpListener.Client.Bind(localEp);
                         break;
                     }
                     catch (Exception ex)

--- a/IL2-SR-Client/packages.config
+++ b/IL2-SR-Client/packages.config
@@ -8,7 +8,7 @@
   <package id="MathNet.Filtering" version="0.4.0" targetFramework="net46" />
   <package id="MathNet.Numerics" version="3.8.0" targetFramework="net46" />
   <package id="MvvmEventBinding" version="1.0.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net481" />
   <package id="NLog" version="4.5.8" targetFramework="net46" />
   <package id="Sentry" version="2.1.4" targetFramework="net461" />
   <package id="Sentry.PlatformAbstractions" version="1.1.0" targetFramework="net461" requireReinstallation="true" />

--- a/IL2-SR-Common/IL2-SR-Common.csproj
+++ b/IL2-SR-Common/IL2-SR-Common.csproj
@@ -58,8 +58,8 @@
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>

--- a/IL2-SR-Common/packages.config
+++ b/IL2-SR-Common/packages.config
@@ -3,7 +3,7 @@
   <package id="Costura.Fody" version="1.6.2" targetFramework="net46" developmentDependency="true" />
   <package id="Extended.Wpf.Toolkit" version="3.2.0" targetFramework="net46" />
   <package id="Fody" version="2.1.2" targetFramework="net46" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net481" />
   <package id="NLog" version="4.5.8" targetFramework="net46" />
   <package id="Octokit" version="0.30.0" targetFramework="net46" />
   <package id="SourceLink.Create.GitHub" version="2.8.0" targetFramework="net46" />

--- a/IL2-SRS-External-Audio/IL2-SRS-External-Audio.csproj
+++ b/IL2-SRS-External-Audio/IL2-SRS-External-Audio.csproj
@@ -46,8 +46,8 @@
     <Reference Include="Easy.MessageHub, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Easy.MessageHub.3.2.1\lib\net35\Easy.MessageHub.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.7.3\lib\net45\NLog.dll</HintPath>

--- a/IL2-SRS-External-Audio/packages.config
+++ b/IL2-SRS-External-Audio/packages.config
@@ -3,6 +3,6 @@
   <package id="Costura.Fody" version="4.1.0" targetFramework="net461" />
   <package id="Easy.MessageHub" version="3.2.1" targetFramework="net461" />
   <package id="Fody" version="6.0.0" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net481" />
   <package id="NLog" version="4.7.3" targetFramework="net461" />
 </packages>

--- a/IL2-SimpleRadio Server/App.config
+++ b/IL2-SimpleRadio Server/App.config
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/IL2-SimpleRadio Server/IL2-SimpleRadio Server.csproj
+++ b/IL2-SimpleRadio Server/IL2-SimpleRadio Server.csproj
@@ -111,8 +111,8 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
@@ -166,8 +166,10 @@
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
@@ -195,6 +197,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.RegularExpressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.RegularExpressions.4.3.1\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/IL2-SimpleRadio Server/packages.config
+++ b/IL2-SimpleRadio Server/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net481" />
   <package id="NLog" version="4.5.8" targetFramework="net46" />
   <package id="Open.NAT" version="2.1.0.0" targetFramework="net46" />
   <package id="PropertyChanged.Fody" version="2.1.3" targetFramework="net46" developmentDependency="true" />
@@ -37,7 +37,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net46" requireReinstallation="true" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" requireReinstallation="true" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net481" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net46" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net46" />
@@ -58,7 +58,7 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" requireReinstallation="true" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net46" requireReinstallation="true" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net481" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net46" />

--- a/IL2-SimpleRadioStandalone.sln
+++ b/IL2-SimpleRadioStandalone.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29424.173
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpusWrapper", "OpusWrapper\OpusWrapper.csproj", "{838BDB0B-5EB1-4C1E-9026-0A8842AC00C6}"
 EndProject

--- a/Installer/App.config
+++ b/Installer/App.config
@@ -1,6 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
This patch will allow other processes to listen to IL-2 telemetry data on the same port as SRS. It also contains updated dependencies that was flagged as having vulnerabilities.